### PR TITLE
[MISC] Quick user-ability update to the header

### DIFF
--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -1,6 +1,6 @@
 ---
 import type { Props } from "@astrojs/starlight/props";
-import SearchDefault from '@astrojs/starlight/components/Search.astro'
+import SearchDefault from "@astrojs/starlight/components/Search.astro";
 import { BsBoxArrowUpRight } from "react-icons/bs";
 import { IconContext } from "react-icons/lib";
 import HomeButton from "./HomeButton.astro";
@@ -9,11 +9,13 @@ const normalPages = Astro.props.sidebar
   .filter((item) => item.type === "link")
   .map((item) => item.href);
 const isNormalPage = normalPages.includes("/" + Astro.props.slug);
+const currentBase = Astro.url.pathname.split("/").slice(0, 2).join("/");
 
-let links: { title: string; href: string }[] = [];
+let links: { title: string; href: string; base: string }[] = [];
 let callToActionLink = {
   title: "",
   href: "",
+  base: "",
 };
 
 Astro.props.sidebar.forEach((item) => {
@@ -22,6 +24,7 @@ Astro.props.sidebar.forEach((item) => {
     links.push({
       title: item.label,
       href: item.href,
+      base: item.href.split("/").slice(0, 2).join("/"),
     });
     return;
   }
@@ -39,6 +42,7 @@ Astro.props.sidebar.forEach((item) => {
     links.push({
       title: item.label,
       href: firstLink.href,
+      base: firstLink.href.split("/").slice(0, 2).join("/"),
     });
   }
 });
@@ -49,7 +53,9 @@ Astro.props.sidebar.forEach((item) => {
   <HomeButton {...Astro.props} />
 
   {/* Sidebar Links */}
-  <div class="flex flex-row gap-x-16 grow justify-center items-center basis-1/2">
+  <div
+    class="flex flex-row gap-x-16 grow justify-center items-center basis-1/2"
+  >
     {
       links.map((link) => (
         <a
@@ -58,29 +64,27 @@ Astro.props.sidebar.forEach((item) => {
         >
           {link.title}
           <div
-            class="max-w-0 group-hover:left-0 group-hover:max-w-full h-[0.2rem] bg-black
-              transition-all duration-300 origin-center relative left-1/2"
+            class={`max-w-0 group-hover:left-0 group-hover:max-w-full h-[0.2rem] bg-black
+              transition-all duration-300 origin-center relative 
+              ${link.base === currentBase ? "left-0 max-w-full" : "left-1/2"}`}
           />
         </a>
       ))
     }
   </div>
 
-    {
-      isNormalPage ? (
-        <a
-          href={callToActionLink.href}
-          class={`btn-primary`}
-        >
-          <span>{callToActionLink.title}</span>
-          <IconContext.Provider value={{ className: "" }}>
-            <BsBoxArrowUpRight />
-          </IconContext.Provider>
-        </a>
-      ) : (
-        <div class="basis-1/5">
-          <SearchDefault {...Astro.props} />
-        </div>
-      )
-    }
+  {
+    isNormalPage ? (
+      <a href={callToActionLink.href} class={`btn-primary`}>
+        <span>{callToActionLink.title}</span>
+        <IconContext.Provider value={{ className: "" }}>
+          <BsBoxArrowUpRight />
+        </IconContext.Provider>
+      </a>
+    ) : (
+      <div class="basis-1/5">
+        <SearchDefault {...Astro.props} />
+      </div>
+    )
+  }
 </div>


### PR DESCRIPTION
Right now, there are no indications which page we're on (unless we take a look at the navbar). This PR adds the underline below the link for indications.

**Home-page:**
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3915d75d-cc4a-4f93-a7a6-f41d664e54e9">

**ELSI:**
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/7398658a-1c93-47af-9cb3-2e4c72a3f0e1">
